### PR TITLE
Updated title font to Archivo Black

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -75,7 +75,7 @@ body {
     --title-accent-width: clamp(34px, 5vw, 46px);
     --title-accent-height: clamp(12px, 3vw, 16px);
     --title-accent-offset: clamp(-24px, -6vw, -18px);
-    font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-light);
     font-size: clamp(1.6rem, 4vw, 2.6rem);
     padding: 0.35rem 0.75rem;
     background: var(--nb-highlight);

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -18,7 +18,8 @@
     --nb-border-soft: #2d2d2d;
 
     /* Typography */
-    --font-family-heading: 'Titillium Web', 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    /* Prefer Archivo (light/regular weights available); fallback to Archivo Black if needed */
+    --font-family-heading: 'Archivo', 'Archivo Black', 'Bebas Neue', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-family-primary: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-family-mono: 'VT323', 'Space Grotesk', 'Inter', monospace;
     --font-weight-light: 300;

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
-        href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=VT323&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700;800&family=Archivo+Black&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=VT323&display=swap"
         rel="stylesheet"
     >
     <link href="https://fonts.googleapis.com/css2?family=Bungee&display=swap" rel="stylesheet">


### PR DESCRIPTION
This pull request updates the heading font stack across the project to prioritize the `Archivo` font family and adjusts the heading font weight for a lighter appearance. These changes improve visual consistency and modernize the typography.

**Typography updates:**

* Updated the heading font stack in `static/css/variables.css` to use `Archivo` as the preferred font, with `Archivo Black` and `Bebas Neue` as fallbacks.
* Modified the Google Fonts import in `templates/base.html` to include the full range of `Archivo` font weights, ensuring light and regular weights are available for headings.

**Style adjustments:**

* Changed the heading font weight in the `body` selector in `static/css/base.css` from bold to light, resulting in a lighter and cleaner heading appearance.